### PR TITLE
cmd_argv[ 0] should be the executable, not the first argument

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@
 build/
 cmake-build-debug/
 .idea/
+.mulle/
 lib/inc/drogon/version.h
 html/
 latex/

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 OpenBSD [unveil(2)][unveil] like function on Linux using [Landlock][landlock] (starting from Linux >= 5.13). Rewritten largely based on [gonack's landlockjail][landlockjail]
 
-**Impoerant:** This is experimental software. DO NOT depend on it for security.
+**Important:** This is experimental software. DO NOT depend on it for security.
 
 ## Documentation
 
@@ -10,7 +10,7 @@ See OpenBSD unveil(2) for details. Like unveil(2), llunveil(2) allows a process 
 
 * Filesystem protection is activated upon calling `unveil(NULL, NULL)`
 
-Instead of activating upon calling the unveil function. Protections have to be commited in llunveil for it to take effect. For example:
+Instead of activating upon calling the unveil function. Protections have to be commited in llunveil for them to take effect. For example:
 
 ```c
 #define LLUNVEIL_USE_UNVEIL // create a macro called `unveil`. Prevent conflict
@@ -31,7 +31,7 @@ assert(fopen("/tmp/some_text.txt", "r") == NULL);
 
 ## How to build
 
-You need a C11 compatiable compiler. And be on Linux >= 5.13 (for the syscall numbers). And CMake for build generation.
+You need a C11 compatible compiler. And be on Linux >= 5.13 (for the syscall numbers). And CMake for build generation.
 
 ```
 mkdir build
@@ -67,6 +67,6 @@ bash: /usr/local/bin/example: Permission denied
 ## TODO
 
 - [ ] Make unit tests
-- [ ] Ensure same behaivour as OpenBSD's
+- [ ] Ensure same behaviour as OpenBSD's
 - [ ] Remove debug error prints
 - [ ] Proper `errno`

--- a/examples/lljail.c
+++ b/examples/lljail.c
@@ -81,7 +81,7 @@ int main(int argc, char *argv[], char **envp) {
 
 
     char *cmd_path = argv[i];
-    char **cmd_argv = argv+i+1;
+    char **cmd_argv = argv+i;
     execvpe(cmd_path, cmd_argv, envp);
     fprintf(stderr, "Failed to execute \"%s\": %s\n", cmd_path,
             strerror(errno));

--- a/llunveil/llunveil.c
+++ b/llunveil/llunveil.c
@@ -7,6 +7,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <errno.h>
 #include <sys/prctl.h>
 #include <sys/stat.h>
 #include <sys/syscall.h>
@@ -142,7 +143,7 @@ static int llunveil_commit()
 static int llunveil_add_rule(const char* path, int64_t permissions)
 {
     if (populate_ruleset(ruleset_fd, path, permissions)) {
-        perror("Could not populate ruleset");
+        fprintf( stderr, "Could not populate ruleset for %s: %s\n", path, strerror(errno));
         return -1;
     }
     return 0;


### PR DESCRIPTION
Otherwise `lljail -rx /lib -rx /bin -- /bin/echo "VfL Bochum 1848"` won't produce any output.